### PR TITLE
Fix: Mount stopping ticks

### DIFF
--- a/src/game/chars/CCharFight.cpp
+++ b/src/game/chars/CCharFight.cpp
@@ -322,6 +322,8 @@ bool CChar::OnAttackedBy(CChar * pCharSrc, bool fCommandPet, bool fShouldReveal)
 		return true;	// self induced
 	if (IsStatFlag(STATF_DEAD|STATF_STONE))
 		return false;
+	if (IsStatFlag(STATF_RIDDEN))
+		return true;
 
 	if (fShouldReveal)
 		pCharSrc->Reveal();	// fix invis exploit


### PR DESCRIPTION
Add check at CChar::OnAttackedBy( to prevent it exec on ridden mounts.

Mounts couldnt pass _CanTick() if they were harmed by anyone.  Timers as Poison gets stopped even if dismounted later. And Mounts  couldnt pass "CChar::death()" until dismount.

